### PR TITLE
Add autoload-cookie.

### DIFF
--- a/evil-paredit.el
+++ b/evil-paredit.el
@@ -21,6 +21,7 @@
 (require 'evil)
 (require 'paredit)
 
+;;;###autoload
 (define-minor-mode evil-paredit-mode
   "Minor mode for setting up Evil with paredit in a single buffer"
   :keymap '()


### PR DESCRIPTION
When the minor mode is turned on evil-paredit is automatically required.
