### PR TITLE
Change evil-paredit-delete from overriding evil-paredit-yank's behavior

### DIFF
--- a/evil-paredit.el
+++ b/evil-paredit.el
@@ -72,7 +72,7 @@ Save in REGISTER or in the kill-ring with YANK-HANDLER."
   (evil-paredit-yank beg end type register yank-handler)
   (if (eq type 'block)
       (evil-apply-on-block #'delete-region beg end nil)
-    (kill-region beg end))
+    (delete-region beg end))
   ;; place cursor on beginning of line
   (when (and (evil-called-interactively-p)
              (eq type 'line))


### PR DESCRIPTION
For non-block types the old version used kill-region for actual deletion. Changed it to delete-region so that it doesn't override evil-paredit-yank that's called right before. The difference is easy to see by typing `dd` followed by `p` or `P` on indented code. The new version puts on new line like it does in vim.
