### PR TITLE
fix call to deprecated function `evil-called-interactively-p'.

### DIFF
--- a/evil-paredit.el
+++ b/evil-paredit.el
@@ -74,7 +74,7 @@ Save in REGISTER or in the kill-ring with YANK-HANDLER."
       (evil-apply-on-block #'delete-region beg end nil)
     (delete-region beg end))
   ;; place cursor on beginning of line
-  (when (and (evil-called-interactively-p)
+  (when (and (called-interactively-p 'any)
              (eq type 'line))
     (evil-first-non-blank)))
 


### PR DESCRIPTION
This function has been deprecated after Emacs 24. See https://github.com/emacs-evil/evil/pull/771/.

It _has_ been added back as a deprecated function, however, so I don't quite know why I encountered it now. Still, I thought why not fix it.